### PR TITLE
Ordenamiento, filtros en los QR de tarima

### DIFF
--- a/src/apps/inventario/api_views/dispositivo.py
+++ b/src/apps/inventario/api_views/dispositivo.py
@@ -33,6 +33,7 @@ class DispositivoViewSet(viewsets.ModelViewSet):
     serializer_class = inv_s.DispositivoSerializer
     queryset = inv_m.Dispositivo.objects.all()
     filter_class = DispositivoFilter
+    ordering = ('entrada')
 
     @action(methods=['get'], detail=False)
     def paquete(self, request, pk=None):

--- a/src/apps/inventario/forms/dispositivo.py
+++ b/src/apps/inventario/forms/dispositivo.py
@@ -429,9 +429,10 @@ class DispositivosTarimaForm(forms.ModelForm):
     """
     class Meta:
         model = inv_m.Dispositivo
-        fields = ('tarima', 'estado', 'etapa', )
+        fields = ('tarima', 'tipo', 'estado', 'etapa',)
         widgets = {
             'tarima': forms.TextInput({'class': 'form-control'}),
+            'tipo': forms.Select(attrs={'class': 'form-control'}),
             'estado': forms.HiddenInput(),
             'etapa': forms.HiddenInput(),
         }

--- a/src/apps/inventario/menus.py
+++ b/src/apps/inventario/menus.py
@@ -79,6 +79,12 @@ dispositivos_children = (
         weight=12,
         icon=" fa-mobile-phone",
     ),
+    ViewMenuItem(
+        "Dispositivos por tarima  ",
+        reverse_lazy('dispositivo_tarima'),
+        weight=12,
+        icon="fa-desktop",
+    ),
 )
 # Repuestos
 repuestos_children = (

--- a/src/apps/inventario/models.py
+++ b/src/apps/inventario/models.py
@@ -476,7 +476,7 @@ class Dispositivo(models.Model):
 
     class Meta:
         verbose_name = "Dispositivo"
-        verbose_name_plural = "Dispositivos"
+        verbose_name_plural = "Dispositivos"        
         indexes = [
             models.Index(fields=['triage']),
         ]

--- a/src/apps/inventario/views/dispositivo.py
+++ b/src/apps/inventario/views/dispositivo.py
@@ -431,9 +431,12 @@ class DispositivosTarimaQr(LoginRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         tarima = self.request.GET['tarima']
+        tipo = self.request.GET['tipo']
+        print(self.request.GET)
         context = super(DispositivosTarimaQr, self).get_context_data(**kwargs)
         context['dispositivo_qr'] = inv_m.Dispositivo.objects.filter(tarima=tarima,
+                                                                     tipo=tipo,
                                                                      estado=inv_m.DispositivoEstado.PD,
-                                                                     etapa=inv_m.DispositivoEtapa.AB)
+                                                                     etapa=inv_m.DispositivoEtapa.AB).order_by('entrada')
 
         return context

--- a/src/apps/inventario/views/entrada.py
+++ b/src/apps/inventario/views/entrada.py
@@ -197,8 +197,10 @@ class ImprimirQr(LoginRequiredMixin, GroupRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ImprimirQr, self).get_context_data(**kwargs)
+        print(inv_m.Dispositivo.objects.filter(entrada=self.object.id,
+                                               entrada_detalle=self.kwargs['detalle']).order_by('triage'))
         context['dispositivo_qr'] = inv_m.Dispositivo.objects.filter(entrada=self.object.id,
-                                                                     entrada_detalle=self.kwargs['detalle'])
+                                                                     entrada_detalle=self.kwargs['detalle']).order_by('entrada')
         return context
 
 

--- a/src/static/js/extrajs/inventario.js
+++ b/src/static/js/extrajs/inventario.js
@@ -109,7 +109,7 @@ class EntradaUpdate {
                 {data: "creado_por"},
                 {
                     data: "",render: function(data, type, full, meta){
-                      if(full.dispositivos_creados == true ){
+                      if(full.dispositivos_creados == true || full.repuestos_creados == true ){
                           if(full.usa_triage == "False"){
                             return "<a href="+full.update_url+" class='btn btn-info btn-editar'>Editar</a>";
                           }else{
@@ -125,7 +125,7 @@ class EntradaUpdate {
                     data: "", render: function(data, type, full, meta){
                       if(full.tipo_entrada != "Especial"){
                           if(full.dispositivos_creados == false){
-                            if(full.usa_triage == "True"){
+                            if(full.usa_triage == "True" && full.util > 0){
                               return "<button class='btn btn-primary btn-dispositivo'>Crear Disp</button>";
                             }else{
                               return "";
@@ -156,7 +156,7 @@ class EntradaUpdate {
                     data: "", render: function(data, type, full, meta){
                       if(full.tipo_entrada != "Especial"){
                         if(full.repuestos_creados == false){
-                          if(full.usa_triage == "True"){
+                          if(full.usa_triage == "True" && full.repuesto > 0){
                               return "<button class='btn btn-warning btn-repuesto'>Crear Rep</button>";
                           }else{
                             return " ";

--- a/src/static/js/extrajs/inventario.js
+++ b/src/static/js/extrajs/inventario.js
@@ -2309,7 +2309,6 @@ class RepuestosList {
 }
 class DispositivoList {
   constructor() {
-
     $('#dispositivo-list-form').submit(function (e) {
         e.preventDefault();
         /**/
@@ -2378,12 +2377,17 @@ class DispositivosQR {
 }
 class DispositivosTarimaList {
   constructor() {
+    $("[for='id_estado']").css({"visibility":"hidden"});
+    $("[for='id_etapa']").css({"visibility":"hidden"});
+    $('#id_tipo').change( function() {
+     var selected_tipo = $('#id_tipo option:selected').val();
+     console.log(selected_tipo);
     $('#dispositivo-tarima-list-form').submit(function (e) {
         e.preventDefault();
         /**/
 
          let tarima  = $("#id_tarima").val();
-         let url = $("#qr-botton").data("url")+"?tarima="+tarima;
+         let url = $("#qr-botton").data("url")+"?tarima="+tarima+"&tipo="+selected_tipo;
          document.getElementById("qr-botton").setAttribute("href", url);
          $('#qr-botton').css({"display":"block"});
         var tablaDispositivos = $('#dispositivo-tarima-table').DataTable({
@@ -2418,6 +2422,8 @@ class DispositivosTarimaList {
 
 
     });
+   });
+
 
   }
 }

--- a/src/templates/inventario/dispositivo/dispositivo_print.html
+++ b/src/templates/inventario/dispositivo/dispositivo_print.html
@@ -1,10 +1,6 @@
 {% load staticfiles %}
-
-
 <img src="{{object.codigo_qr.url}}" class="img-thumbnail" alt="" width="85" height="85"></td>
 <h5>{{object.triage}} </h5>
-
-
 {% block extra_js %}
 <script>
 window.onload= function () { window.print();window.close();   }

--- a/src/templates/inventario/dispositivo/dispositivo_tarima_list.html
+++ b/src/templates/inventario/dispositivo/dispositivo_tarima_list.html
@@ -18,11 +18,10 @@
 							<h3 class="box-title">Filtros</h3>
 						</div>
 						<div class="box-body">
-							{% csrf_token %}
-								<h4>Tarima</h4>
+							{% csrf_token %}							
 							 {% for field in form %}
 							<div class="form-group">
-								{{field}}
+								{{field.label_tag}} {{field}}
 							</div>
 							{% endfor %}
 						</div>

--- a/src/templates/inventario/repuesto/repuesto_detail.html
+++ b/src/templates/inventario/repuesto/repuesto_detail.html
@@ -76,13 +76,6 @@
 									<br>
 								</td>
 							</tr>
-              <tr>
-								<th>QR</th>
-								<td>
-									<img src="{{repuesto.codigo_qr.url}}" class="img-thumbnail" alt="">
-									<br>
-								</td>
-							</tr>
 						</table>
 					</div>
 				</div>


### PR DESCRIPTION
## Correccion en los QR
- A la hora de imprimir los QR ya estan ordenados
- Se agrego el filtro para buscar por tipo de dipositivo


***

- [ ] Requiere `collectstatic`
- [ ] Requiere `migración`
- [ ] Requiere `pip install`
